### PR TITLE
fixed configuration so Solarium client is passed core path not core name

### DIFF
--- a/DependencyInjection/NelmioSolariumExtension.php
+++ b/DependencyInjection/NelmioSolariumExtension.php
@@ -54,7 +54,7 @@ class NelmioSolariumExtension extends Extension
                 'host'    => $config['adapter']['host'],
                 'port'    => $config['adapter']['port'],
                 'path'    => $config['adapter']['path'],
-                'core'    => $core,
+                'core'    => (null !== $core) ? $config['adapter']['cores'][$core] : null,
                 'timeout' => $config['adapter']['timeout'],
             ),
         );

--- a/Tests/NelmioSolariumExtensionTest.php
+++ b/Tests/NelmioSolariumExtensionTest.php
@@ -59,6 +59,13 @@ class NelmioSolariumExtensionTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('Solarium_Client', $container->get('solarium.client.a'));
         $this->assertInstanceOf('Solarium_Client', $container->get('solarium.client.b'));
+
+        $adapterOptions = array(
+            'a'             => $container->get('solarium.client.a')->getOption('adapteroptions'),
+            'b'             => $container->get('solarium.client.b')->getOption('adapteroptions'),
+            );
+        $this->assertEquals('core_a', $adapterOptions['a']['core']);
+        $this->assertEquals('core_b', $adapterOptions['b']['core']);
     }
 
     private function createCompiledContainerForConfig($config)


### PR DESCRIPTION
Previous change made passed the core name rather than the core path to the Solarium client as the 'core' option.  This change fixes this.
