### PR TITLE
made logger build up query times in ms

### DIFF
--- a/Logger.php
+++ b/Logger.php
@@ -70,7 +70,7 @@ class Logger extends Solarium_Plugin_Abstract implements DataCollectorInterface
         if ($this->currentRequest !== $request) {
             throw new \RuntimeException('Requests differ');
         }
-        $this->queries[] = array('request' => $request, 'response' => $response, 'duration' => microtime(true) - $this->currentStartTime);
+        $this->queries[] = array('request' => $request, 'response' => $response, 'duration' => (microtime(true) - $this->currentStartTime) * 1000);
         $this->currentRequest = null;
         $this->currentStartTime = null;
     }


### PR DESCRIPTION
The query times were using `microtime(true)` which returns seconds, but being shown as in milliseconds. This change makes the query times get counted in milliseconds instead, so the times aren't out by a factor of 1,000.
