### PR TITLE
Update Solarium to 3.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "symfony/framework-bundle": "2.*",
-        "solarium/solarium": "3.0.*"
+        "solarium/solarium": "3.1.*"
     },
     "require-dev": {
         "symfony/yaml": "2.*"


### PR DESCRIPTION
No BC Breaks for this new release, only more options to work with Solr 41
