### PR TITLE
Added a Solarium Data Fixture Loader Command

### DIFF
--- a/Command/LoadFixturesCommand.php
+++ b/Command/LoadFixturesCommand.php
@@ -6,6 +6,7 @@ use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 
 /**
  * @author Baldur Rensch <brensch@gmail.com>
@@ -63,7 +64,15 @@ class LoadFixturesCommand extends ContainerAwareCommand
 
         /** @var $executor \Solarium\Support\DataFixtures\Executor */
         $executor = $this->getContainer()->get('solarium.fixtures.executor.default');
-        $executor->execute($loader->getFixtures());
+
+        $fixtures = $loader->getFixtures();
+        foreach ($fixtures as $fixture) {
+            if ($fixture instanceof ContainerAwareInterface) {
+                $fixture->setContainer($this->getContainer());
+            }
+        }
+
+        $executor->execute($fixtures);
     }
 } 
 

--- a/Command/LoadFixturesCommand.php
+++ b/Command/LoadFixturesCommand.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Nelmio\SolariumBundle\Command;
+
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @author Baldur Rensch <brensch@gmail.com>
+ */
+class LoadFixturesCommand extends ContainerAwareCommand
+{
+    protected function configure()
+    {
+        $this->setName('nelmio:solarium:fixtures')
+            ->setDescription('Loads Solarium fixtures')
+            ->addOption(
+                'fixtures',
+                null,
+                InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
+                'The directory or file to load data fixtures from.'
+            )
+            ->addOption(
+                'append',
+                null,
+                InputOption::VALUE_NONE,
+                'Append the data fixtures instead of deleting all data from the database first.'
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $append = $input->getOption('append');
+
+        $dirOrFile = $input->getOption('fixtures');
+        if ($dirOrFile) {
+            $paths = is_array($dirOrFile) ? $dirOrFile : array($dirOrFile);
+        } else {
+            $paths = array();
+            foreach ($this->getApplication()->getKernel()->getBundles() as $bundle) {
+                $dirName = $bundle->getPath().'/DataFixtures/Solarium';
+
+                if (is_dir($dirName)) {
+                    $output->writeln(sprintf('  <comment>></comment> <info>%s</info>', $dirName));
+                    $paths[] = $dirName;
+                }
+            }
+        }
+
+        /** @var \Solarium\Support\DataFixtures\Loader $loader */
+        $loader = $this->getContainer()->get('solarium.fixtures.loader');
+        foreach ($paths as $path) {
+            $loader->loadFromDirectory($path);
+        }
+
+        if (!$append) {
+            $output->writeln('<comment>  > Purging Solr</comment>');
+            $purger = $this->getContainer()->get('solarium.fixtures.purger.default');
+            $purger->purge();
+        }
+
+        /** @var $executor \Solarium\Support\DataFixtures\Executor */
+        $executor = $this->getContainer()->get('solarium.fixtures.executor.default');
+        $executor->execute($loader->getFixtures());
+    }
+} 
+

--- a/README.md
+++ b/README.md
@@ -202,6 +202,18 @@ nelmio_solarium:
             adapter_class: Solarium\Client\Adapter\Http
 ```
 
+## Loading Fixtures
+
+There is a command to load fixtures:
+
+```bash
+$ app/console nelmio:solarium:fixtures --append
+```
+
+The command is modeled after the DoctrineDataFixture Bundle's command. The command expects the data fixtures to
+be in the `AcmeBundle/DataFixtures/Solarium` directory. Every fixture has to implement the
+`Solarium\Support\DataFixtures\FixtureInterface` interface.
+
 ## License
 
 Released under the MIT License, see LICENSE.

--- a/Resources/config/fixtures.xml
+++ b/Resources/config/fixtures.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <parameters>
+        <parameter key="solarium.fixtures.loader.class">Solarium\Support\DataFixtures\Loader</parameter>
+    </parameters>
+
+    <services>
+        <service id="solarium.fixtures.loader" class="%solarium.fixtures.loader.class%" />
+    </services>
+</container>

--- a/Tests/NelmioSolariumExtensionTest.php
+++ b/Tests/NelmioSolariumExtensionTest.php
@@ -385,7 +385,41 @@ class NelmioSolariumExtensionTest extends \PHPUnit_Framework_TestCase
             ),
             $loadBalancedEndpoints
         );
+    }
 
+    public function testDataFixtures()
+    {
+        $config = array(
+            'endpoints' => array(
+                'endpoint1' => array(
+                    'host' => 'localhost',
+                    'port' => 123,
+                    'core' => 'core1',
+                ),
+                'endpoint2' => array(
+                    'host' => 'localhost',
+                    'port' => 123,
+                    'core' => 'core2',
+                )
+            ),
+            'clients' => array(
+                'client1' => array(
+                    'endpoints' => array('endpoint2'),
+                ),
+                'client2' => array(
+                    'endpoints' => array('endpoint1'),
+                )
+            ),
+        );
+
+        $container = $this->createCompiledContainerForConfig($config);
+
+        foreach (array_keys($config['clients']) as $client) {
+            $this->assertInstanceOf('Solarium\Support\DataFixtures\Executor', $container->get('solarium.fixtures.executor.' . $client));
+            $this->assertInstanceOf('Solarium\Support\DataFixtures\Purger', $container->get('solarium.fixtures.purger.' . $client));
+        }
+
+        $this->assertInstanceOf('Solarium\Support\DataFixtures\Loader', $container->get('solarium.fixtures.loader'));
     }
 
     private function createCompiledContainerForConfig($config, $debug = false)

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "symfony/framework-bundle": "~2.1",
-        "solarium/solarium": "~3.0"
+        "solarium/solarium": "dev-develop"
     },
     "autoload": {
         "psr-0": { "Nelmio\\SolariumBundle": "" }

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "symfony/framework-bundle": "~2.1",
-        "solarium/solarium": "dev-develop"
+        "solarium/solarium": "~3.0"
     },
     "autoload": {
         "psr-0": { "Nelmio\\SolariumBundle": "" }


### PR DESCRIPTION
This adds fixture loading capabilities to the bundle. Basically only a command and a couple of services are needed. That way, it's easy to load Solr data fixtures in a Symfony application. The feature is merged in Solarium, however, not in master (that's why I have updated the composer file, this should be changed back before this is merged. 

I will add Alice related capabilities that use this in the AliceBundle.
