### PR TITLE
Added reference to Symfony's event dispatcher

### DIFF
--- a/DependencyInjection/NelmioSolariumExtension.php
+++ b/DependencyInjection/NelmioSolariumExtension.php
@@ -71,6 +71,7 @@ class NelmioSolariumExtension extends Extension
             $clients[$name] = new Reference($clientName);
 
             $container->setDefinition($clientName, $clientDefinition);
+            $clientDefinition->addMethodCall('setEventDispatcher', array(new Reference('event_dispatcher')));
 
             if ($name == $defaultClient) {
                 $container->setAlias('solarium.client', $clientName);


### PR DESCRIPTION
Hi,

I just noticed Solarium was using its own instance of Symfony's event dispatcher, preventing to use it with tagged dependencies (i.e. `kernel.event_subscriber`).

Now the Solarium client relies on the existing `event_dispatcher` service within the Symfony app.

Ben