### PR TITLE
Don't stop the "solr" event if it was never started

### DIFF
--- a/Logger.php
+++ b/Logger.php
@@ -135,7 +135,7 @@ class Logger extends SolariumPlugin implements DataCollectorInterface, \Serializ
             throw new \RuntimeException('Requests differ');
         }
 
-        if (null !== $this->stopwatch) {
+        if (null !== $this->stopwatch && $this->stopwatch->isStarted('solr')) {
             $this->stopwatch->stop('solr');
         }
 
@@ -150,7 +150,7 @@ class Logger extends SolariumPlugin implements DataCollectorInterface, \Serializ
     {
         $endTime = microtime(true) - $this->currentStartTime;
 
-        if (null !== $this->stopwatch) {
+        if (null !== $this->stopwatch && $this->stopwatch->isStarted('solr')) {
             $this->stopwatch->stop('solr');
         }
 


### PR DESCRIPTION
Bugfix in the symfony dev environment (2.8.8): 

If the solr instance is not running and the HttpException while trying to query the solr is correctly handled there will be a LogicException from trying to stop the event afterwards. 

Check if the event is started before it is being stopped. 
