### PR TITLE
Fixed usage of non-Twig paths in profiler panel

### DIFF
--- a/Resources/config/logger.xml
+++ b/Resources/config/logger.xml
@@ -8,7 +8,10 @@
     </parameters>
     <services>
         <service id="solarium.data_collector" class="%solarium.data_collector.class%">
-            <tag name="data_collector" template="NelmioSolariumBundle:DataCollector:solarium" id="solr" />
+            <tag name="data_collector"
+                template="@NelmioSolarium/DataCollector/solarium"
+                id="solr"
+            />
             <tag name="monolog.logger" channel="solr" />
             <call method="setLogger">
                 <argument type="service" id="logger" on-invalid="ignore" />

--- a/Resources/views/DataCollector/solarium.html.twig
+++ b/Resources/views/DataCollector/solarium.html.twig
@@ -1,4 +1,4 @@
-{% extends app.request.isXmlHttpRequest ? 'WebProfilerBundle:Profiler:ajax_layout.html.twig' : 'WebProfilerBundle:Profiler:layout.html.twig' %}
+{% extends app.request.isXmlHttpRequest ? '@WebProfiler/Profiler/ajax_layout.html.twig' : '@WebProfiler/Profiler/layout.html.twig' %}
 
 {% block toolbar %}
     {% if collector.querycount > 0 %}
@@ -29,7 +29,7 @@
                 <span>{{ '%0.2f'|format(collector.totaltime * 1000) }} ms</span>
             </div>
         {% endset %}
-        {% include 'WebProfilerBundle:Profiler:toolbar_item.html.twig' with { 'link': profiler_url } %}
+        {% include '@WebProfiler/Profiler/toolbar_item.html.twig' with { 'link': profiler_url } %}
     {% endif %}
 {% endblock %}
 


### PR DESCRIPTION
Using SolariumBundle v2.3.0 with the latest versions of Symfony (3.3.2), Twig (2.4.3) and WebProfileBundle (3.3.2) the SOLR template in the profiler can not be loaded. 

This PR fixes it :)

see: https://github.com/symfony/web-profiler-bundle/commit/50d6db262e70d0e1be39ed914db19d8b3f7a645e

and https://github.com/snc/SncRedisBundle/pull/337/files