### PR TITLE
Add simple-phpunit as dev dependency (and updated tests)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+/Tests export-ignore
+phpunit.xml.dist export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-vendor
+vendor/
 composer.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+language: php
+
+sudo: false
+
+cache:
+  directories:
+    - vendor
+    - $HOME/.composer/cache/files
+
+matrix:
+  fast_finish: true
+  include:
+    - php: 7.1
+      env: COMPOSER_FLAGS="--prefer-lowest" SYMFONY_DEPRECATIONS_HELPER=weak
+    - php: 7.0
+      env: SYMFONY_VERSION=2.8.*@dev
+    - php: 7.0
+      env: DEPENDENCIES=dev
+    - php: 5.6
+      env: SYMFONY_VERSION=2.8.*@dev
+    - php: 5.6
+      env: DEPENDENCIES=dev
+
+
+before_install:
+    - if [[ $TRAVIS_PHP_VERSION != hhvm ]]; then phpenv config-rm xdebug.ini; fi
+    - if [ "$SYMFONY_VERSION" != "" ]; then composer require --dev --no-update "symfony/symfony:$SYMFONY_VERSION"; fi
+    - if [ "$DEPENDENCIES" = "dev" ]; then perl -pi -e 's/^}$/,"minimum-stability":"dev"}/' composer.json; fi;
+
+install: travis_retry composer update $COMPOSER_FLAGS
+
+script: ./vendor/bin/simple-phpunit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 3.0.0 - unreleased
 
+ * Updated tests, use ::class instead of FQDN, minor fixes
+ * Added simplephp to require-dev
  * Removed support of `dsn` option for the `endpoint` parameter
 
 ## 2.4.0 (2017-08-08)

--- a/Tests/NelmioSolariumExtensionTest.php
+++ b/Tests/NelmioSolariumExtensionTest.php
@@ -13,7 +13,9 @@ namespace Nelmio\SolariumBundle\Tests;
 
 use Nelmio\SolariumBundle\DependencyInjection\NelmioSolariumExtension;
 use PHPUnit\Framework\TestCase;
+use Solarium\Client;
 use Solarium\Core\Client\Adapter\Http;
+use Solarium\Core\Client\Adapter\Curl;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\FrameworkExtension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -31,10 +33,10 @@ class NelmioSolariumExtensionTest extends TestCase
 
         $container = $this->createCompiledContainerForConfig($config);
 
-        $this->assertInstanceOf('Solarium\Client', $container->get('solarium.client'));
+        $this->assertInstanceOf(Client::class, $container->get('solarium.client'));
 
         $adapter = $container->get('solarium.client')->getAdapter();
-        $this->assertInstanceOf('Solarium\Core\Client\Adapter\Curl', $adapter);
+        $this->assertInstanceOf(Curl::class, $adapter);
 
         $endpoint = $container->get('solarium.client')->getEndpoint();
 

--- a/Tests/NelmioSolariumExtensionTest.php
+++ b/Tests/NelmioSolariumExtensionTest.php
@@ -11,15 +11,22 @@
 
 namespace Nelmio\SolariumBundle\Tests;
 
+use Nelmio\SolariumBundle\ClientRegistry;
 use Nelmio\SolariumBundle\DependencyInjection\NelmioSolariumExtension;
+use Nelmio\SolariumBundle\Logger;
 use PHPUnit\Framework\TestCase;
 use Solarium\Client;
 use Solarium\Core\Client\Adapter\Http;
 use Solarium\Core\Client\Adapter\Curl;
+use Solarium\Core\Client\Endpoint;
+use Solarium\Core\Event\Events;
+use Solarium\Core\Plugin\AbstractPlugin;
+use Solarium\Plugin\Loadbalancer\Loadbalancer;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\FrameworkExtension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class NelmioSolariumExtensionTest extends TestCase
 {
@@ -38,7 +45,9 @@ class NelmioSolariumExtensionTest extends TestCase
         $adapter = $container->get('solarium.client')->getAdapter();
         $this->assertInstanceOf(Curl::class, $adapter);
 
+        /** @var Endpoint $endpoint */
         $endpoint = $container->get('solarium.client')->getEndpoint();
+        $this->assertInstanceOf(Endpoint::class, $endpoint);
 
         $this->assertEquals('http', $endpoint->getOption('scheme'));
         $this->assertEquals('127.0.0.1', $endpoint->getOption('host'));
@@ -57,12 +66,14 @@ class NelmioSolariumExtensionTest extends TestCase
 
         $container = $this->createCompiledContainerForConfig($config);
 
-        $this->assertInstanceOf('Solarium\Client', $container->get('solarium.client'));
+        $this->assertInstanceOf(Client::class, $container->get('solarium.client'));
 
         $adapter = $container->get('solarium.client')->getAdapter();
-        $this->assertInstanceOf('Solarium\Core\Client\Adapter\Curl', $adapter);
+        $this->assertInstanceOf(Curl::class, $adapter);
 
+        /** @var Endpoint $endpoint */
         $endpoint = $container->get('solarium.client')->getEndpoint();
+        $this->assertInstanceOf(Endpoint::class, $endpoint);
 
         $this->assertEquals('http', $endpoint->getOption('scheme'));
         $this->assertEquals('127.0.0.1', $endpoint->getOption('host'));
@@ -86,8 +97,8 @@ class NelmioSolariumExtensionTest extends TestCase
 
         $container = $this->createCompiledContainerForConfig($config);
 
-        $this->assertInstanceOf('Solarium\Client', $container->get('solarium.client'));
-        $this->assertInstanceOf($adapterClass, $container->get('solarium.client')->getAdapter());
+        $this->assertInstanceOf(Client::class, $container->get('solarium.client'));
+        $this->assertInstanceOf(Http::class, $container->get('solarium.client')->getAdapter());
     }
 
     public function testLoadCustomClient()
@@ -95,15 +106,15 @@ class NelmioSolariumExtensionTest extends TestCase
         $config = array(
             'clients' => array(
                 'default' => array(
-                    'client_class' => 'Nelmio\SolariumBundle\Tests\StubClient'
+                    'client_class' => StubClient::class
                 )
             )
         );
 
         $container = $this->createCompiledContainerForConfig($config);
 
-        $this->assertInstanceOf('Nelmio\SolariumBundle\Tests\StubClient', $container->get('solarium.client'));
-        $this->assertInstanceOf('Solarium\Core\Client\Adapter\Curl', $container->get('solarium.client')->getAdapter());
+        $this->assertInstanceOf(StubClient::class, $container->get('solarium.client'));
+        $this->assertInstanceOf(Curl::class, $container->get('solarium.client')->getAdapter());
     }
 
     public function testDefaultClient()
@@ -113,16 +124,16 @@ class NelmioSolariumExtensionTest extends TestCase
             'clients' => array(
                 'client1' => array(),
                 'client2' => array(
-                    'client_class' => 'Nelmio\SolariumBundle\Tests\StubClient'
+                    'client_class' => StubClient::class
                 )
             ),
         );
 
         $container = $this->createCompiledContainerForConfig($config);
 
-        $this->assertInstanceOf('Solarium\Client', $container->get('solarium.client.client1'));
-        $this->assertInstanceOf('Nelmio\SolariumBundle\Tests\StubClient', $container->get('solarium.client'));
-        $this->assertInstanceOf('Nelmio\SolariumBundle\Tests\StubClient', $container->get('solarium.client.client2'));
+        $this->assertInstanceOf(Client::class, $container->get('solarium.client.client1'));
+        $this->assertInstanceOf(StubClient::class, $container->get('solarium.client'));
+        $this->assertInstanceOf(StubClient::class, $container->get('solarium.client.client2'));
     }
 
     public function testPlugins()
@@ -130,19 +141,19 @@ class NelmioSolariumExtensionTest extends TestCase
         $config = array(
           'clients' => array(
             'client' => array(
-              'plugins' => array('plugin1' => array('plugin_service' => 'my_plugin'), 'plugin2' => array('plugin_class' => 'Nelmio\SolariumBundle\Tests\MyPluginClass'))
+              'plugins' => array('plugin1' => array('plugin_service' => 'my_plugin'), 'plugin2' => array('plugin_class' => MyPluginClass::class))
             )
           ),
         );
 
-        $container = $this->createCompiledContainerForConfig($config, true, array('my_plugin' => new Definition('Nelmio\SolariumBundle\Tests\MyPluginClass')));
+        $container = $this->createCompiledContainerForConfig($config, true, array('my_plugin' => new Definition(MyPluginClass::class)));
 
         $client = $container->get('solarium.client');
         $plugin1 = $client->getPlugin('plugin1');
         $plugin2 = $client->getPlugin('plugin2');
 
-        $this->assertInstanceOf('Nelmio\SolariumBundle\Tests\MyPluginClass', $plugin1);
-        $this->assertInstanceOf('Nelmio\SolariumBundle\Tests\MyPluginClass', $plugin2);
+        $this->assertInstanceOf(MyPluginClass::class, $plugin1);
+        $this->assertInstanceOf(MyPluginClass::class, $plugin2);
     }
 
     public function testEndpoints()
@@ -173,13 +184,16 @@ class NelmioSolariumExtensionTest extends TestCase
 
         $container = $this->createCompiledContainerForConfig($config);
 
+        /** @var Endpoint $endpoint */
         $endpoint = $container->get('solarium.client')->getEndpoint();
+        $this->assertInstanceOf(Endpoint::class, $endpoint);
 
         $this->assertEquals('endpoint1', $endpoint->getOption('key'));
         $this->assertEquals('localhost', $endpoint->getOption('host'));
         $this->assertEquals('123', $endpoint->getOption('port'));
         $this->assertEquals('core1', $endpoint->getOption('core'));
 
+        /** @var Endpoint[] $endpoints */
         $endpoints = $container->get('solarium.client')->getEndpoints();
 
         $this->assertEquals(3, count($container->get('solarium.client')->getEndpoints()));
@@ -231,7 +245,9 @@ class NelmioSolariumExtensionTest extends TestCase
 
         $container = $this->createCompiledContainerForConfig($config);
 
+        /** @var Endpoint $endpoint */
         $endpoint = $container->get('solarium.client')->getEndpoint();
+        $this->assertInstanceOf(Endpoint::class, $endpoint);
 
         $this->assertEquals(1, count($container->get('solarium.client')->getEndpoints()));
 
@@ -266,13 +282,16 @@ class NelmioSolariumExtensionTest extends TestCase
 
         $container = $this->createCompiledContainerForConfig($config);
 
+        /** @var Endpoint $endpoint */
         $endpoint = $container->get('solarium.client')->getEndpoint();
+        $this->assertInstanceOf(Endpoint::class, $endpoint);
 
         $this->assertEquals('endpoint2', $endpoint->getOption('key'));
         $this->assertEquals('localhost', $endpoint->getOption('host'));
         $this->assertEquals('123', $endpoint->getOption('port'));
         $this->assertEquals('core2', $endpoint->getOption('core'));
 
+        /** @var Endpoint[] $endpoints */
         $endpoints = $container->get('solarium.client')->getEndpoints();
 
         $this->assertEquals(2, count($container->get('solarium.client')->getEndpoints()));
@@ -318,11 +337,11 @@ class NelmioSolariumExtensionTest extends TestCase
         );
         $container = $this->createCompiledContainerForConfig($config);
         $clientRegistry = $container->get('solarium.client_registry');
-        $this->assertInstanceOf('Nelmio\SolariumBundle\ClientRegistry', $clientRegistry);
-        $this->assertInstanceOf('Solarium\Client', $clientRegistry->getClient('client1'));
+        $this->assertInstanceOf(ClientRegistry::class, $clientRegistry);
+        $this->assertInstanceOf(Client::class, $clientRegistry->getClient('client1'));
         $this->assertEquals(array('client1', 'client2'), $clientRegistry->getClientNames());
 
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         $this->assertNotNull($clientRegistry->getClient());
     }
 
@@ -332,17 +351,18 @@ class NelmioSolariumExtensionTest extends TestCase
 
         $container = $this->createCompiledContainerForConfig($config, true);
 
-        $this->assertInstanceOf('Nelmio\SolariumBundle\Logger', $container->get('solarium.data_collector'));
+        $this->assertInstanceOf(Logger::class, $container->get('solarium.data_collector'));
 
+        /** @var EventDispatcherInterface $eventDispatcher */
         $eventDispatcher = $container->get('solarium.client')->getEventDispatcher();
-        $this->assertInstanceOf('Symfony\Component\EventDispatcher\EventDispatcherInterface', $eventDispatcher);
-        $preExecuteListeners = $eventDispatcher->getListeners(\Solarium\Core\Event\Events::PRE_EXECUTE_REQUEST);
+        $this->assertInstanceOf(EventDispatcherInterface::class, $eventDispatcher);
+        $preExecuteListeners = $eventDispatcher->getListeners(Events::PRE_EXECUTE_REQUEST);
         $this->assertEquals(1, count($preExecuteListeners));
-        $this->assertInstanceOf('Nelmio\SolariumBundle\Logger', $preExecuteListeners[0][0]);
+        $this->assertInstanceOf(Logger::class, $preExecuteListeners[0][0]);
         $this->assertEquals('preExecuteRequest', $preExecuteListeners[0][1]);
-        $postExecuteListeners = $eventDispatcher->getListeners(\Solarium\Core\Event\Events::POST_EXECUTE_REQUEST);
+        $postExecuteListeners = $eventDispatcher->getListeners(Events::POST_EXECUTE_REQUEST);
         $this->assertEquals(1, count($postExecuteListeners));
-        $this->assertInstanceOf('Nelmio\SolariumBundle\Logger', $postExecuteListeners[0][0]);
+        $this->assertInstanceOf(Logger::class, $postExecuteListeners[0][0]);
         $this->assertEquals('postExecuteRequest', $postExecuteListeners[0][1]);
     }
 
@@ -378,6 +398,7 @@ class NelmioSolariumExtensionTest extends TestCase
 
         $client = $container->get('solarium.client');
 
+        /** @var Endpoint[] $endpoints */
         $endpoints = $client->getEndpoints();
 
         $this->assertCount(1, $endpoints);
@@ -387,7 +408,9 @@ class NelmioSolariumExtensionTest extends TestCase
         $clientPlugins = $client->getPlugins();
         $this->assertArrayHasKey('loadbalancer', $clientPlugins);
 
+        /** @var Loadbalancer $loadBalancerPlugin */
         $loadBalancerPlugin = $client->getPlugin('loadbalancer');
+        $this->assertInstanceOf(Loadbalancer::class, $loadBalancerPlugin);
         $this->assertEquals($loadBalancerPlugin, $container->get('solarium.client.client1.load_balancer'));
 
         $loadBalancedEndpoints = $loadBalancerPlugin->getEndpoints();
@@ -435,10 +458,10 @@ class NelmioSolariumExtensionTest extends TestCase
     }
 }
 
-class StubClient extends \Solarium\Client
+class StubClient extends Client
 {
 }
 
-class MyPluginClass extends \Solarium\Core\Plugin\Plugin {
+class MyPluginClass extends AbstractPlugin {
 
 }

--- a/Tests/NelmioSolariumExtensionTest.php
+++ b/Tests/NelmioSolariumExtensionTest.php
@@ -12,12 +12,14 @@
 namespace Nelmio\SolariumBundle\Tests;
 
 use Nelmio\SolariumBundle\DependencyInjection\NelmioSolariumExtension;
+use PHPUnit\Framework\TestCase;
+use Solarium\Core\Client\Adapter\Http;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\FrameworkExtension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 
-class NelmioSolariumExtensionTest extends \PHPUnit_Framework_TestCase
+class NelmioSolariumExtensionTest extends TestCase
 {
     public function testLoadEmptyConfiguration()
     {
@@ -69,7 +71,7 @@ class NelmioSolariumExtensionTest extends \PHPUnit_Framework_TestCase
 
     public function testLoadCustomAdapter()
     {
-        $adapter = $this->getMock('Solarium\Core\Client\Adapter\Http');
+        $adapter = $this->createMock(Http::class);
         $adapterClass = get_class($adapter);
 
         $config = array(

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,12 @@
         }
     ],
     "require": {
+        "php": ">=5.5",
         "symfony/framework-bundle": "^2.3 || ^3.0 || ^4.0",
         "solarium/solarium": "^3.3"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "5.*"
     },
     "autoload": {
         "psr-4": { "Nelmio\\SolariumBundle\\": "" }

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "solarium/solarium": "^3.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "5.*"
+        "symfony/phpunit-bridge": "~3.3@dev"
     },
     "autoload": {
         "psr-4": { "Nelmio\\SolariumBundle\\": "" }


### PR DESCRIPTION
- [x] Added simple-phpunit as -dev dependency
- [x] updated tests with usage of `::class` to get the FQDN of classes.
- [x] Updated minor PHP Version to 5.5
- [x] Updated changelog
