### PR TITLE
Fix typo in UPGRADING description

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -4,7 +4,7 @@
 
 ### Endpoint configuration changes (v3.0.0)
 The `dsn` option has been removed from the `endpoints` configuration.
-Here an example of the accepted options fot the `endpoint` parameter.
+Here an example of the accepted options for the `endpoints` parameter:
 
 
 ```yaml


### PR DESCRIPTION
This just fixes a typo in the description and adds the correct parameter name `endpoints` to it.