### PR TITLE
fix Symfony 4.2 deprecation + make some services public

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -25,8 +25,13 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('nelmio_solarium');
+        $treeBuilder = new TreeBuilder('nelmio_solarium');
+        if (method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            // BC layer for symfony/config < 4.2
+            $rootNode = $treeBuilder->root('nelmio_solarium');
+        }
 
         $rootNode
             ->children()

--- a/DependencyInjection/NelmioSolariumExtension.php
+++ b/DependencyInjection/NelmioSolariumExtension.php
@@ -13,6 +13,7 @@ namespace Nelmio\SolariumBundle\DependencyInjection;
 
 use Solarium\Core\Client\Endpoint;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
@@ -61,14 +62,15 @@ class NelmioSolariumExtension extends Extension
                 $clientClass = 'Solarium\Client';
             }
             $clientDefinition = new Definition($clientClass);
+            $clientDefinition->setPublic(true);
             $clients[$name] = new Reference($clientName);
 
             $container->setDefinition($clientName, $clientDefinition);
             $clientDefinition->addMethodCall('setEventDispatcher', array(new Reference('event_dispatcher')));
 
             if ($name == $defaultClient) {
-                $container->setAlias('solarium.client', $clientName);
-                $container->setAlias($clientClass, $clientName);
+                $container->setAlias('solarium.client', new Alias($clientName, true));
+                $container->setAlias($clientClass, new Alias($clientName, true));
             }
 
             //If some specific endpoints are given

--- a/Resources/config/logger.xml
+++ b/Resources/config/logger.xml
@@ -7,7 +7,7 @@
         <parameter key="solarium.data_collector.class">Nelmio\SolariumBundle\Logger</parameter>
     </parameters>
     <services>
-        <service id="solarium.data_collector" class="%solarium.data_collector.class%">
+        <service id="solarium.data_collector" class="%solarium.data_collector.class%" public="true">
             <tag name="data_collector"
                 template="@NelmioSolarium/DataCollector/solarium"
                 id="solr"

--- a/Resources/config/registry.xml
+++ b/Resources/config/registry.xml
@@ -9,7 +9,7 @@
     </parameters>
 
     <services>
-        <service id="solarium.client_registry" class="%solarium.client_registry.class%">
+        <service id="solarium.client_registry" class="%solarium.client_registry.class%" public="true">
             <argument type="collection"></argument>
             <argument>null</argument>
         </service>

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "solarium/solarium": "^3.3 || ^4.0"
     },
     "require-dev": {
-        "symfony/phpunit-bridge": "~3.3@dev"
+        "symfony/phpunit-bridge": "^4.2"
     },
     "autoload": {
         "psr-4": { "Nelmio\\SolariumBundle\\": "" }


### PR DESCRIPTION
- fix deprecation for config when using Symfony 4.2 (see https://github.com/symfony/symfony/blob/master/UPGRADE-4.2.md#config, https://github.com/sensiolabs/SensioFrameworkExtraBundle/commit/a07247f0128b607a4c839b32f61f3ec7ecdc4e76)
- make some services public (as tests are relying on that actually and probably also lots of users out there?)