### PR TITLE
Solarium 5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,15 +11,12 @@ matrix:
   fast_finish: true
   include:
     - php: 7.3
-      env: COMPOSER_FLAGS="--prefer-lowest" SYMFONY_DEPRECATIONS_HELPER=weak
-    - php: 7.1
-      env: SYMFONY_VERSION=2.8.*@dev
+      env: COMPOSER_FLAGS="--prefer-lowest"
+    - php: 7.2
     - php: 7.1
       env: DEPENDENCIES=dev
 
 before_install:
-    - if [[ $TRAVIS_PHP_VERSION != hhvm ]]; then phpenv config-rm xdebug.ini; fi
-    - if [ "$SYMFONY_VERSION" != "" ]; then composer require --dev --no-update "symfony/symfony:$SYMFONY_VERSION"; fi
     - if [ "$DEPENDENCIES" = "dev" ]; then perl -pi -e 's/^}$/,"minimum-stability":"dev"}/' composer.json; fi;
 
 install: travis_retry composer update $COMPOSER_FLAGS

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ matrix:
     - php: 7.3
       env: COMPOSER_FLAGS="--prefer-lowest"
     - php: 7.2
-    - php: 7.1
       env: DEPENDENCIES=dev
 
 before_install:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 ### Security
 
+## [v4.0.0](https://github.com/nelmio/NelmioSolariumBundle/releases/tag/v4.0.0) - 2019-xx-xx
+### Changed
+ - Removed support for PHP 7.1
+ - Removed support for unmaintained Symfony versions
+ - Removed support for Solarium < 5
+### Fixed
+- Fixed Symfony 4.4 deprecations
+
 ## [v3.0.0](https://github.com/nelmio/NelmioSolariumBundle/releases/tag/v3.0.0) - 2019-06-18
 ### Fixed
  - Fixed documentation on Changelog

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,11 @@
 # Upgrading
 
+## Upgrading from v3.x to v4.x
+From version 4 on this bundle requires Solarium 5. 
+In case you were using a custom `path` option for endpoints you need to adjust it. 
+
+See https://solarium.readthedocs.io/en/stable/getting-started/#pitfall-when-upgrading-from-earlier-versions-to-5x
+
 ## Upgrading from v2.x to v3.x
 
 ### Endpoint configuration changes (v3.0.0)

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
         "symfony/framework-bundle": "^3.4 || ^4.2",
         "solarium/solarium": "^5.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -16,11 +16,11 @@
     ],
     "require": {
         "php": "^7.1",
-        "symfony/framework-bundle": "^2.8 || ^3.0 || ^4.0",
-        "solarium/solarium": "^4.0 < 4.3.0"
+        "symfony/framework-bundle": "^3.4 || ^4.2",
+        "solarium/solarium": "^5.0"
     },
     "require-dev": {
-        "symfony/phpunit-bridge": "^4.2"
+        "symfony/phpunit-bridge": "^4.3"
     },
     "autoload": {
         "psr-4": {
@@ -29,7 +29,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "3.x-dev"
+            "dev-master": "4.x-dev"
         }
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,6 +7,9 @@
         colors="true"
         bootstrap="vendor/autoload.php"
 >
+    <php>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[direct]=0" />
+    </php>
     <testsuites>
         <testsuite name="NelmioSolariumBundle Test Suite">
             <directory>./tests/</directory>

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -23,7 +23,7 @@ class Configuration implements ConfigurationInterface
     /**
      * {@inheritDoc}
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('nelmio_solarium');
 
@@ -46,7 +46,7 @@ class Configuration implements ConfigurationInterface
                             ->scalarNode('scheme')->defaultValue('http')->end()
                             ->scalarNode('host')->defaultValue('127.0.0.1')->end()
                             ->scalarNode('port')->defaultValue(8983)->end()
-                            ->scalarNode('path')->defaultValue('/solr')->end()
+                            ->scalarNode('path')->defaultValue('/')->end()
                             ->scalarNode('core')->end()
                             ->scalarNode('timeout')->defaultValue(5)->end()
                         ->end()

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -77,7 +77,7 @@ class Logger extends SolariumPlugin implements DataCollectorInterface, \Serializ
         );
     }
 
-    public function getName()
+    public function getName(): string
     {
         return 'solr';
     }

--- a/tests/NelmioSolariumExtensionTest.php
+++ b/tests/NelmioSolariumExtensionTest.php
@@ -51,7 +51,7 @@ class NelmioSolariumExtensionTest extends TestCase
 
         $this->assertEquals('http', $endpoint->getScheme());
         $this->assertEquals('127.0.0.1', $endpoint->getHost());
-        $this->assertEquals('/solr', $endpoint->getPath());
+        $this->assertEquals('', $endpoint->getPath());
         $this->assertEquals(8983, $endpoint->getPort());
         $this->assertEquals('5', $endpoint->getTimeout());
     }
@@ -77,7 +77,7 @@ class NelmioSolariumExtensionTest extends TestCase
 
         $this->assertEquals('http', $endpoint->getScheme());
         $this->assertEquals('127.0.0.1', $endpoint->getHost());
-        $this->assertEquals('/solr', $endpoint->getPath());
+        $this->assertEquals('', $endpoint->getPath());
         $this->assertEquals(8983, $endpoint->getPort());
         $this->assertEquals('5', $endpoint->getTimeout());
     }
@@ -271,6 +271,7 @@ class NelmioSolariumExtensionTest extends TestCase
                     'host' => 'localhost',
                     'port' => 123,
                     'core' => 'core2',
+                    'path' =>'/custom_prefix',
                 )
             ),
             'clients' => array(
@@ -302,6 +303,7 @@ class NelmioSolariumExtensionTest extends TestCase
         $this->assertEquals('localhost', $endpoints['endpoint1']->getHost());
         $this->assertEquals(123, $endpoints['endpoint1']->getPort());
         $this->assertEquals('core1', $endpoints['endpoint1']->getCore());
+        $this->assertEquals('http://localhost:123/solr/core1/', $endpoints['endpoint1']->getCoreBaseUri());
 
         $this->assertTrue(isset($endpoints['endpoint2']));
         $this->assertEquals('endpoint2', $endpoints['endpoint2']->getKey());
@@ -309,6 +311,8 @@ class NelmioSolariumExtensionTest extends TestCase
         $this->assertEquals('localhost', $endpoints['endpoint2']->getHost());
         $this->assertEquals(123, $endpoints['endpoint2']->getPort());
         $this->assertEquals('core2', $endpoints['endpoint2']->getCore());
+        $this->assertEquals('/custom_prefix', $endpoints['endpoint2']->getPath());
+        $this->assertEquals('http://localhost:123/custom_prefix/solr/core2/', $endpoints['endpoint2']->getCoreBaseUri());
     }
 
     public function testClientRegistry()
@@ -411,7 +415,6 @@ class NelmioSolariumExtensionTest extends TestCase
         /** @var Loadbalancer $loadBalancerPlugin */
         $loadBalancerPlugin = $client->getPlugin('loadbalancer');
         $this->assertInstanceOf(Loadbalancer::class, $loadBalancerPlugin);
-        $this->assertEquals($loadBalancerPlugin, $container->get('solarium.client.client1.load_balancer'));
 
         $loadBalancedEndpoints = $loadBalancerPlugin->getEndpoints();
         $this->assertCount(2, $loadBalancedEndpoints);
@@ -422,7 +425,6 @@ class NelmioSolariumExtensionTest extends TestCase
             ),
             $loadBalancedEndpoints
         );
-
     }
 
     private function createCompiledContainerForConfig($config, $debug = false, $extraServices = array())


### PR DESCRIPTION
- fixes https://github.com/nelmio/NelmioSolariumBundle/issues/92
- require solarium 5 (BC break due to changed defaults for path option
on endpoints)
- drop support for outdated Symfony versions
- fixed some deprecations with Symfony 4.4 (dev)
- drop support for php 7.1
- tested it on a big Symfony 4.3 work project 