### PR TITLE
test maintained symfony release versions explicitly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,12 @@ cache:
 matrix:
   fast_finish: true
   include:
+    - php: 7.2
+      env: SYMFONY_REQUIRE=3.4.*
+    - php: 7.3
+      env: SYMFONY_REQUIRE=4.3.*
+    - php: 7.4
+      env: SYMFONY_REQUIRE=4.4.*
     - php: 7.3
       env: COMPOSER_FLAGS="--prefer-lowest"
     - php: 7.2
@@ -17,7 +23,8 @@ matrix:
 
 before_install:
     - if [ "$DEPENDENCIES" = "dev" ]; then composer config minimum-stability dev; fi;
+    - composer global require --no-progress --no-scripts --no-plugins symfony/flex
 
-install: travis_retry composer update $COMPOSER_FLAGS
+install: travis_retry composer update $COMPOSER_FLAGS --prefer-dist
 
 script: ./vendor/bin/simple-phpunit


### PR DESCRIPTION
Since we are adding Symfony 5 support in https://github.com/nelmio/NelmioSolariumBundle/pull/98 we should adjust the travis build so we can test all major symfony versions explicitly.