### PR TITLE
Resolve Deprecations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^7.2",
         "symfony/framework-bundle": "^4.3 || ^5.0",
-        "solarium/solarium": "^5.2"
+        "solarium/solarium": "^6.0"
     },
     "require-dev": {
         "symfony/phpunit-bridge": "^5.0"

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -29,12 +29,7 @@ class Configuration implements ConfigurationInterface
     {
         $treeBuilder = new TreeBuilder('nelmio_solarium');
 
-        if (method_exists($treeBuilder, 'getRootNode')) {
-            $rootNode = $treeBuilder->getRootNode();
-        } else {
-            // BC layer for symfony/config < 4.2
-            $rootNode = $treeBuilder->root('nelmio_solarium');
-        }
+        $rootNode = $treeBuilder->getRootNode();
 
         $rootNode
             ->children()

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -20,6 +20,8 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
  */
 class Configuration implements ConfigurationInterface
 {
+    const COMPOSER_PACKAGE_NAME = "nelmio/solarium-bundle";
+
     /**
      * {@inheritDoc}
      */
@@ -49,7 +51,7 @@ class Configuration implements ConfigurationInterface
                             ->scalarNode('path')->defaultValue('/')->end()
                             ->scalarNode('core')->end()
                             ->scalarNode('timeout')
-                                ->setDeprecated('Configuring a timeout per endpoint is deprecated. Configure the timeout on the client adapter instead.')
+                                ->setDeprecated(self::COMPOSER_PACKAGE_NAME, '5.0', 'Configuring a timeout per endpoint is deprecated. Configure the timeout on the client adapter instead.')
                             ->end()
                         ->end()
                     ->end()
@@ -74,7 +76,7 @@ class Configuration implements ConfigurationInterface
                         ->children()
                             ->scalarNode('client_class')->cannotBeEmpty()->defaultValue(Client::class)->end()
                             ->scalarNode('adapter_class')
-                                ->setDeprecated('Configuring an adapter class is deprecated. Configure an adapter service instead.')
+                                ->setDeprecated(self::COMPOSER_PACKAGE_NAME, '5.0', 'Configuring an adapter class is deprecated. Configure an adapter service instead.')
                             ->end()
                             ->scalarNode('adapter_timeout')->end()
                             ->scalarNode('adapter_service')->end()


### PR DESCRIPTION
I had some ugly deprecation notices in my log and I fixed them:

`Since symfony/config 5.1: The signature of method "Symfony\Component\Config\Definition\Builder\NodeDefinition::setDeprecated()" requires 3 arguments: "string $package, string $version, string $message", not defining them is deprecated.`

Also I removed an unnecessary check because the current branch doesn't support Symfony lower than 4.2 

