### PR TITLE
fix deprecation

### DIFF
--- a/src/DependencyInjection/NelmioSolariumExtension.php
+++ b/src/DependencyInjection/NelmioSolariumExtension.php
@@ -21,7 +21,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 
 /**
  * @author Igor Wiedler <igor@wiedler.ch>


### PR DESCRIPTION
```
The "Symfony\Component\HttpKernel\DependencyInjection\Extension" class is considered internal since Symfony 7.1, 
to be deprecated in 8.1; 
use Symfony\Component\DependencyInjection\Extension\Extension instead. 
It may change without further notice. 
You should not use it from "Nelmio\SolariumBundle\DependencyInjection\NelmioSolariumExtension".
```