### PR TITLE
Allow Symfony ^8.0 to be used

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
                     -   php: 8.4
                         SYMFONY_REQUIRE: 7.3.*
                     -   php: 8.4
+                        SYMFONY_REQUIRE: 8.0.*
+                    -   php: 8.4
                         stability: dev
 
         steps:

--- a/composer.json
+++ b/composer.json
@@ -13,13 +13,13 @@
     "require": {
         "php": "^8.1",
         "solarium/solarium": "^6.4.1",
-        "symfony/dependency-injection": "^6.4 || ^7.3",
-        "symfony/framework-bundle": "^6.4 || ^7.3",
-        "symfony/http-kernel": "^6.4 || ^7.3"
+        "symfony/dependency-injection": "^6.4 || ^7.3 || ^8.0",
+        "symfony/framework-bundle": "^6.4 || ^7.3 || ^8.0",
+        "symfony/http-kernel": "^6.4 || ^7.3 || ^8.0"
     },
     "require-dev": {
-        "symfony/phpunit-bridge": "^7.3",
-        "symfony/stopwatch": "^6.4 || ^7.3"
+        "symfony/phpunit-bridge": "^7.3 || ^8.0",
+        "symfony/stopwatch": "^6.4 || ^7.3 || ^8.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/DependencyInjection/NelmioSolariumExtension.php
+++ b/src/DependencyInjection/NelmioSolariumExtension.php
@@ -28,10 +28,7 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class NelmioSolariumExtension extends Extension
 {
-    /**
-     * @return void
-     */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $config = $this->processConfiguration(new Configuration(), $configs);
 

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -64,10 +64,7 @@ class Logger extends SolariumPlugin implements DataCollectorInterface, \Serializ
         ];
     }
 
-    /**
-     * @return void
-     */
-    public function collect(HttpRequest $request, HttpResponse $response, /** \Throwable */ $exception = null)
+    public function collect(HttpRequest $request, HttpResponse $response, /** \Throwable */ $exception = null): void
     {
         if (isset($this->currentRequest)) {
             $this->failCurrentRequest();


### PR DESCRIPTION
This updates two method signatures to match changes in Symfony 8, where types have been added. I made the changes in a way to maintain compatibility with previous Symfony versions.

However, you will need to decide whether to treat `\Nelmio\SolariumBundle\Logger` as part of the public API of this bundle and an extension point. Technically, inheriting from the Logger is not prevented (it's not `final`), so adding the `void` return type is a breaking change.